### PR TITLE
bugfix optimizing num_topics as a CTM hparam

### DIFF
--- a/octis/models/contextualized_topic_models/networks/inference_network.py
+++ b/octis/models/contextualized_topic_models/networks/inference_network.py
@@ -23,7 +23,7 @@ class ContextualInferenceNetwork(nn.Module):
         """
         super(ContextualInferenceNetwork, self).__init__()
         assert isinstance(input_size, int), "input_size must by type int."
-        assert isinstance(output_size, int), "output_size must be type int."
+        assert isinstance(output_size, int) or isinstance(output_size, np.int64), "output_size must be type int."
         assert isinstance(hidden_sizes, tuple), \
             "hidden_sizes must be type tuple."
         assert activation in ['softplus', 'relu', 'sigmoid', 'tanh', 'leakyrelu',


### PR DESCRIPTION
OCTIS throws the following error message when trying to optimise `num_topics` as a CTM hyper-parameter: `output_size must be type int.`

How to reproduce:
```
from octis.models.CTM import CTM
from octis.dataset.dataset import Dataset
from octis.optimization.optimizer import Optimizer
from skopt.space.space import  Categorical
from octis.evaluation_metrics.coherence_metrics import Coherence


dataset = Dataset()
dataset.fetch_dataset("M10")

model = CTM(num_topics=10, num_epochs=1)
npmi = Coherence(texts=dataset.get_corpus())

search_space = {"num_topics": Categorical({10})}
optimizer=Optimizer()
optimization_result = optimizer.optimize(
    model, dataset, npmi, search_space, number_of_call=1, 
    model_runs=1)
```

The reason is that there is an assert making sure the `output_size` attribute of CTM (which is equal to `num_topics`) is of type int, but the optimizer returns values of type np.int64.

This PR updates the assert to accept values of type np.int64 (as well as int) for the `output_size` attribute of CTM.