### PR TITLE
Adding top_words parameter to CTM model

### DIFF
--- a/octis/models/CTM.py
+++ b/octis/models/CTM.py
@@ -111,7 +111,8 @@ class CTM(AbstractModel):
                                  num_samples=self.hyperparameters['num_samples'],
                                  topic_prior_mean=self.hyperparameters["prior_mean"],
                                  reduce_on_plateau=self.hyperparameters['reduce_on_plateau'],
-                                 topic_prior_variance=self.hyperparameters["prior_variance"])
+                                 topic_prior_variance=self.hyperparameters["prior_variance"],
+                                 top_word = top_words)
             self.model.fit(x_train, x_valid, verbose=False)
             result = self.inference(x_test)
             return result
@@ -133,7 +134,8 @@ class CTM(AbstractModel):
                              num_samples=self.hyperparameters['num_samples'],
                              topic_prior_mean=self.hyperparameters["prior_mean"],
                              reduce_on_plateau=self.hyperparameters['reduce_on_plateau'],
-                             topic_prior_variance=self.hyperparameters["prior_variance"])
+                             topic_prior_variance=self.hyperparameters["prior_variance"],
+                             top_word = top_words)
 
 
         self.model.fit(x_train, None, verbose=False)

--- a/octis/models/ETM.py
+++ b/octis/models/ETM.py
@@ -70,12 +70,12 @@ class ETM(BaseETM):
         self.optimizer = None
         self.embeddings = None
 
-    def train_model(self, dataset, hyperparameters=None, top_words=10):
+    def train_model(self, dataset, hyperparameters=None, top_words=10, op_path='checkpoint.pt'):
         if hyperparameters is None:
             hyperparameters = {}
         self.set_model(dataset, hyperparameters)
         self.top_word = top_words
-        self.early_stopping = EarlyStopping(patience=5, verbose=True)
+        self.early_stopping = EarlyStopping(patience=5, verbose=True, path=op_path)
 
         for epoch in range(0, self.hyperparameters['num_epochs']):
             continue_training = self._train_epoch(epoch)

--- a/octis/models/contextualized_topic_models/models/ctm.py
+++ b/octis/models/contextualized_topic_models/models/ctm.py
@@ -18,7 +18,7 @@ class CTM(object):
 
     def __init__(self, input_size, bert_input_size, inference_type="zeroshot", num_topics=10, model_type='prodLDA',
                  hidden_sizes=(100, 100), activation='softplus', dropout=0.2, learn_priors=True, batch_size=64,
-                 lr=2e-3, momentum=0.99, solver='adam', num_epochs=100, num_samples=10,
+                 lr=2e-3, momentum=0.99, solver='adam', num_epochs=100, num_samples=10, top_word = 10,
                  reduce_on_plateau=False, topic_prior_mean=0.0, topic_prior_variance=None, num_data_loader_workers=0):
         """
         :param input_size: int, dimension of input
@@ -80,6 +80,7 @@ class CTM(object):
         self.batch_size = batch_size
         self.lr = lr
         self.num_samples = num_samples
+        self.top_word = top_word
         self.bert_size = bert_input_size
         self.momentum = momentum
         self.solver = solver
@@ -342,6 +343,7 @@ class CTM(object):
         Args
             k : (int) number of words to return per topic, default 10.
         """
+        k = self.top_word
         assert k <= self.input_size, "k must be <= input size."
         component_dists = self.best_components
         topics = defaultdict(list)

--- a/octis/models/contextualized_topic_models/models/ctm.py
+++ b/octis/models/contextualized_topic_models/models/ctm.py
@@ -365,21 +365,19 @@ class CTM(object):
         top_doc_arr = np.array([i.cpu().detach().numpy() for i in top_doc])
         return top_doc_arr
 
-    def get_topics(self, k=10):
+    def get_topics(self):
         """
         Retrieve topic words.
 
-        Args
-            k : (int) number of words to return per topic, default 10.
         """
-        k = self.top_word
-        assert k <= self.input_size, "k must be <= input size."
+        assert self.top_words <= (
+            self.input_size, "top_words must be <= input size.")
         component_dists = self.best_components
         topics = defaultdict(list)
         topics_list = []
         if self.num_topics is not None:
             for i in range(self.num_topics):
-                _, idxs = torch.topk(component_dists[i], k)
+                _, idxs = torch.topk(component_dists[i], self.top_words)
                 component_words = [self.train_data.idx2token[idx]
                                    for idx in idxs.cpu().numpy()]
                 topics[i] = component_words


### PR DESCRIPTION
The `train_model` function in CTM has the `top_words` parameter but it doesn't get passed to the `ctm` class as it doesn't have any argument corresponding to the same. This results in CTM returning topics of length 10 regardless of the values of `top_words` in the `train_model` function. For example the below code will return topics of length 10 even though we've set the value of `top_words` to 5.

```
from octis.models.CTM import CTM
from octis.dataset.dataset import Dataset

dataset = Dataset()
dataset.fetch_dataset("M10")

model = CTM(num_topics=10)
output = model.train_model(dataset, top_words=5)
npmi = Coherence(texts=dataset.get_corpus(), topk=5)
```

This PR adds the `top_word` parameter to the `ctm` class and modifies the `get_topics` function to use the value of `top_words` passed by the user (default value is still 10)