### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-gensim==4.2.0
+gensim>=4.2.0,<5.0
 nltk
 pandas
 spacy
-scikit-learn==1.1.0
+scikit-learn>=1.1.0,<2.0
 scikit-optimize>=0.8.1
 matplotlib
 torch
-numpy==1.23.0
+numpy>=1.23.0,<2.0
 libsvm
 flask
 sentence_transformers


### PR DESCRIPTION
Due to its very specific dependency requirements (exactly equal to specific subversions), this library is starting to become incompatible with other libraries in the ML space. I propose to follow the convention of only requiring a specific major version, and allowing the package manager freedom to decide on the minor version. I don't see specific reasons why OCTIS is not compatible with higher minor versions of gensim, scikit-learn and numpy.