### PR TITLE
Improvements to Null Checks and Device Assignment in LSI and ETM Models

### DIFF
--- a/octis/models/ETM.py
+++ b/octis/models/ETM.py
@@ -16,7 +16,7 @@ class ETM(BaseETM):
         self, num_topics=10, num_epochs=100, t_hidden_size=800, rho_size=300,
         embedding_size=300, activation='relu', dropout=0.5, lr=0.005,
         optimizer='adam', batch_size=128, clip=0.0, wdecay=1.2e-6, bow_norm=1,
-        device='cpu', train_embeddings=True, embeddings_path=None,
+        device='cuda', train_embeddings=True, embeddings_path=None,
             embeddings_type='pickle', binary_embeddings=True,
             headerless_embeddings=False, use_partitions=True):
         """
@@ -131,9 +131,12 @@ class ETM(BaseETM):
             self.train_tokens, self.train_counts = self.preprocess(
                 vocab2id, data_corpus, None)
 
-        self.device = torch.device(
-            "cuda" if torch.cuda.is_available() else "cpu")
-
+        if isinstance(self.device, str):
+            self.device = torch.device(self.device)
+        
+        if (self.device.type == 'cuda' and not torch.cuda.is_available()) or (self.device.type == 'mps' and torch.backends.mps.is_available()):
+            self.device = torch.device('cpu')
+        
         self.set_default_hyperparameters(hyperparameters)
         self.load_embeddings()
         # define model and optimizer

--- a/octis/models/ETM.py
+++ b/octis/models/ETM.py
@@ -134,7 +134,7 @@ class ETM(BaseETM):
         if isinstance(self.device, str):
             self.device = torch.device(self.device)
         
-        if (self.device.type == 'cuda' and not torch.cuda.is_available()) or (self.device.type == 'mps' and torch.backends.mps.is_available()):
+        if (self.device.type == 'cuda' and not torch.cuda.is_available()) or (self.device.type == 'mps' and not torch.backends.mps.is_available()):
             self.device = torch.device('cpu')
         
         self.set_default_hyperparameters(hyperparameters)

--- a/octis/models/LSI.py
+++ b/octis/models/LSI.py
@@ -106,10 +106,10 @@ class LSI(AbstractModel):
         else:
             partition = [dataset.get_corpus(), []]
 
-        if self.id2word == None:
+        if self.id2word is None:
             self.id2word = corpora.Dictionary(dataset.get_corpus())
 
-        if self.id_corpus == None:
+        if self.id_corpus is None:
             self.id_corpus = [self.id2word.doc2bow(
                 document) for document in partition[0]]
 


### PR DESCRIPTION
### Description
This pull request addresses two main issues found in the `models.LSI` and `models.ETM` modules.

### Changes Made
1. **Improved Null Checks in `models.LSI`:**
   - Updated comparisons from `== None` to `is None` in two locations within the `models.LSI` module. This change ensures a more reliable and Pythonic way of handling null checks.

2. **Refined Device Assignment in `models.ETM`:**
   - Addressed three specific device assignment issues:
     - **CPU Use on CUDA-capable Devices:** Even when the device parameter was explicitly set to 'cpu' on CUDA-capable devices, the model was still being assigned to a GPU. This has been corrected to respect the user's device preference.
     - **GPU Selection on Multi-GPU Systems:** Previously, specifying a particular GPU (e.g., 'cuda:1') on systems with multiple GPUs incorrectly defaulted to the first GPU due to automatic checks and assignments. This update ensures that the specified GPU is used as intended.
     - **MPS Acceleration on Apple Devices:** On Apple machines supporting 'mps', attempting to use MPS acceleration would default to 'cpu' when 'cuda' was unavailable. This behavior has been adjusted to properly recognize and utilize 'mps' if specified.

### Rationale
These updates enhanced the usability and functionality of the affected models. By ensuring that null checks are more robust and device assignments adhere to user specifications, we can provide a more predictable and efficient user experience.