### PR TITLE
Add `saved_kv` parameter to eval metrics

### DIFF
--- a/octis/evaluation_metrics/coherence_metrics.py
+++ b/octis/evaluation_metrics/coherence_metrics.py
@@ -72,7 +72,7 @@ class Coherence(AbstractMetric):
 
 
 class WECoherencePairwise(AbstractMetric):
-    def __init__(self, word2vec_path=None, binary=False, topk=10):
+    def __init__(self, word2vec_path=None, binary=False, topk=10, saved_kv=False):
         """
         Initialize metric
 
@@ -83,6 +83,7 @@ class WECoherencePairwise(AbstractMetric):
         word2vec_path : if word2vec_file is specified retrieves word embeddings file (in word2vec format)
         to compute similarities, otherwise 'word2vec-google-news-300' is downloaded
         binary : True if the word2vec file is binary, False otherwise (default False)
+        saved_kv : True if the word2vec file is saved in gensim's format (using KeyedVectors.save()) (default False)
         """
         super().__init__()
 
@@ -91,6 +92,8 @@ class WECoherencePairwise(AbstractMetric):
         self.word2vec_path = word2vec_path
         if word2vec_path is None:
             self._wv = api.load('word2vec-google-news-300')
+        elif saved_kv:
+            self._wv = KeyedVectors.load(word2vec_path)
         else:
             self._wv = KeyedVectors.load_word2vec_format(
                 word2vec_path, binary=self.binary)
@@ -144,7 +147,7 @@ class WECoherencePairwise(AbstractMetric):
 
 
 class WECoherenceCentroid(AbstractMetric):
-    def __init__(self, topk=10, word2vec_path=None, binary=True):
+    def __init__(self, topk=10, word2vec_path=None, binary=True, saved_kv=False):
         """
         Initialize metric
 
@@ -152,6 +155,7 @@ class WECoherenceCentroid(AbstractMetric):
         ----------
         topk : how many most likely words to consider
         w2v_model_path : a word2vector model path, if not provided, google news 300 will be used instead
+        saved_kv : True if the word2vec file is saved in gensim's format (using KeyedVectors.save()) (default False)
         """
         super().__init__()
 
@@ -160,6 +164,8 @@ class WECoherenceCentroid(AbstractMetric):
         self.word2vec_path = word2vec_path
         if self.word2vec_path is None:
             self._wv = api.load('word2vec-google-news-300')
+        elif saved_kv:
+            self._wv = KeyedVectors.load(self.word2vec_path)
         else:
             self._wv = KeyedVectors.load_word2vec_format(
                 self.word2vec_path, binary=self.binary)

--- a/octis/evaluation_metrics/diversity_metrics.py
+++ b/octis/evaluation_metrics/diversity_metrics.py
@@ -91,7 +91,7 @@ class InvertedRBO(AbstractMetric):
 
 class WordEmbeddingsInvertedRBO(AbstractMetric):
 
-    def __init__(self, topk=10, weight=0.9, normalize=True, word2vec_path=None, binary=True):
+    def __init__(self, topk=10, weight=0.9, normalize=True, word2vec_path=None, binary=True, saved_kv=False):
         """
         Initialize metric WE-IRBO-Match
 
@@ -102,6 +102,7 @@ class WordEmbeddingsInvertedRBO(AbstractMetric):
         :param weight: Weight of each agreement at depth d. When set to 1.0, there is no weight, the rbo returns to
         average overlap. (Default 0.9)
         :param normalize: if true, normalize the cosine similarity
+        :param saved_kv: True if the word2vec file is saved in gensim's format (using KeyedVectors.save())
         """
         super().__init__()
         self.topk = topk
@@ -111,6 +112,8 @@ class WordEmbeddingsInvertedRBO(AbstractMetric):
         self.word2vec_path = word2vec_path
         if word2vec_path is None:
             self._wv = api.load('word2vec-google-news-300')
+        elif saved_kv:
+            self._wv = KeyedVectors.load(word2vec_path)
         else:
             self._wv = KeyedVectors.load_word2vec_format(word2vec_path, binary=self.binary)
 
@@ -145,7 +148,7 @@ def get_word2index(list1, list2):
 
 
 class WordEmbeddingsInvertedRBOCentroid(AbstractMetric):
-    def __init__(self, topk=10, weight=0.9, normalize=True, word2vec_path=None, binary=True):
+    def __init__(self, topk=10, weight=0.9, normalize=True, word2vec_path=None, binary=True, saved_kv=False):
         super().__init__()
         self.topk = topk
         self.weight = weight
@@ -154,6 +157,8 @@ class WordEmbeddingsInvertedRBOCentroid(AbstractMetric):
         self.word2vec_path = word2vec_path
         if word2vec_path is None:
             self.wv = api.load('word2vec-google-news-300')
+        elif saved_kv:
+            self.wv = KeyedVectors.load(word2vec_path)
         else:
             self.wv = KeyedVectors.load_word2vec_format( word2vec_path, binary=self.binary)
 

--- a/octis/evaluation_metrics/similarity_metrics.py
+++ b/octis/evaluation_metrics/similarity_metrics.py
@@ -59,7 +59,7 @@ class WordEmbeddingsRBOCentroid(WordEmbeddingsInvertedRBOCentroid):
 
 
 class WordEmbeddingsPairwiseSimilarity(AbstractMetric):
-    def __init__(self, word2vec_path=None, topk=10, binary=False):
+    def __init__(self, word2vec_path=None, topk=10, binary=False, saved_kv=False):
         """
         Initialize metric WE pairwise similarity
 
@@ -68,10 +68,13 @@ class WordEmbeddingsPairwiseSimilarity(AbstractMetric):
         :param topk: top k words on which the topic diversity will be computed
         :param word2vec_path: word embedding space in gensim word2vec format
         :param binary: If True, indicates whether the data is in binary word2vec format.
+        :param saved_kv: True if the word2vec file is saved in gensim's format (using KeyedVectors.save())
         """
         super().__init__()
         if word2vec_path is None:
             self.wv = api.load('word2vec-google-news-300')
+        elif saved_kv:
+            self.wv = KeyedVectors.load(word2vec_path)
         else:
             self.wv = KeyedVectors.load_word2vec_format( word2vec_path, binary=binary)
 
@@ -104,7 +107,7 @@ class WordEmbeddingsPairwiseSimilarity(AbstractMetric):
 
 
 class WordEmbeddingsCentroidSimilarity(AbstractMetric):
-    def __init__(self, word2vec_path=None, topk=10, binary=False):
+    def __init__(self, word2vec_path=None, topk=10, binary=False, saved_kv=False):
         """
         Initialize metric WE centroid similarity
 
@@ -113,11 +116,13 @@ class WordEmbeddingsCentroidSimilarity(AbstractMetric):
         :param topk: top k words on which the topic diversity will be computed
         :param word2vec_path: word embedding space in gensim word2vec format
         :param binary: If True, indicates whether the data is in binary word2vec format.
-
+        :param saved_kv: True if the word2vec file is saved in gensim's format (using KeyedVectors.save())
         """
         super().__init__()
         if word2vec_path is None:
             self.wv = api.load('word2vec-google-news-300')
+        elif saved_kv:
+            self.wv = KeyedVectors.load(word2vec_path)
         else:
             self.wv = KeyedVectors.load_word2vec_format(word2vec_path, binary=binary)
         self.topk = topk
@@ -161,7 +166,7 @@ def get_word2index(list1, list2):
 
 
 class WordEmbeddingsWeightedSumSimilarity(AbstractMetric):
-    def __init__(self, id2word, word2vec_path=None, topk=10, binary=False):
+    def __init__(self, id2word, word2vec_path=None, topk=10, binary=False, saved_kv=False):
         """
         Initialize metric WE Weighted Sum similarity
 
@@ -169,11 +174,13 @@ class WordEmbeddingsWeightedSumSimilarity(AbstractMetric):
         :param topk: top k words on which the topic diversity will be computed
         :param word2vec_path: word embedding space in gensim word2vec format
         :param binary: If True, indicates whether the data is in binary word2vec format.
-
+        :param saved_kv: True if the word2vec file is saved in gensim's format (using KeyedVectors.save())
         """
         super().__init__()
         if word2vec_path is None:
             self.wv = api.load('word2vec-google-news-300')
+        elif saved_kv:
+            self.wv = KeyedVectors.load(word2vec_path)
         else:
             self.wv = KeyedVectors.load_word2vec_format(word2vec_path, binary=binary)
         self.topk = topk


### PR DESCRIPTION
Small change: adds the ability for embedding-related evaluation metrics to directly load saved `gensim` `KeyedVector` objects rather than needing them to be saved in a format understood by `load_word2vec_format`.