### PR TITLE
fix: typo on vectorizer function call

### DIFF
--- a/octis/preprocessing/preprocessing.py
+++ b/octis/preprocessing/preprocessing.py
@@ -264,7 +264,7 @@ class Preprocessing:
             self.preprocessing_steps.append('filter words with document frequency lower than ' + str(self.min_df) +
                                             ' and higher than ' + str(self.max_df))
             self.preprocessing_steps.append('filter words with less than ' + str(self.min_chars) + " character")
-            vectorizer = TfidfVectorizer(df_max_freq=self.max_df, df_min_freq=self.min_df, vocabulary=self.vocabulary,
+            vectorizer = TfidfVectorizer(max_df=self.max_df, min_df=self.min_df, vocabulary=self.vocabulary,
                                          token_pattern=r"(?u)\b\w{" + str(self.min_chars) + ",}\b",
                                          lowercase=self.lowercase, stop_words=self.stopwords)
 


### PR DESCRIPTION
Fix function call to `TfidfVectorizer` changing wrong paramaters name